### PR TITLE
Increase timeout to wait for data product

### DIFF
--- a/api/app/dataproduct.py
+++ b/api/app/dataproduct.py
@@ -20,7 +20,7 @@ async def fetch_dataproduct(dataspace: str, product: str, source: str, payload: 
         gateway = config["product_gateway_url"]
         url = f"{gateway}/{product}?source={quote_plus(source)}"
 
-        async with httpx.AsyncClient() as client:
+        async with httpx.AsyncClient(timeout=30) as client:
             res = await client.post(url, json=payload)
             return res
     except anyio.EndOfStream:


### PR DESCRIPTION
In some cases the default timeout of 5 seconds was reached. This PR increases it to 30 seconds to allow for some cold starts of productizers and underlying APIs.