### PR TITLE
Pinning scanner build image version

### DIFF
--- a/scanner/Dockerfile
+++ b/scanner/Dockerfile
@@ -1,5 +1,5 @@
 # --- BUILD ---
-FROM ghcr.io/ioxiocom/nodejs-base:ubuntu22.04-node18 AS build
+FROM ghcr.io/ioxiocom/nodejs-base:ubuntu22.04-node18@sha256:7ba92e190c476e077c6276b716fbed32b1198dbae0d89e233f3f5c260c4d2c3d AS build
 
 ARG API_BASE_URL="https://api.tags.ioxio.dev"
 


### PR DESCRIPTION
Build for scanner is failing on newer versions of build image, did not find a resolution need a hotfix that works today. This is it.