### PR TITLE
Fix issue with building scanner on latest docker image

### DIFF
--- a/scanner/Dockerfile
+++ b/scanner/Dockerfile
@@ -1,5 +1,5 @@
 # --- BUILD ---
-FROM ghcr.io/ioxiocom/nodejs-base:ubuntu22.04-node18@sha256:7ba92e190c476e077c6276b716fbed32b1198dbae0d89e233f3f5c260c4d2c3d AS build
+FROM ghcr.io/ioxiocom/nodejs-base:ubuntu22.04-node18 AS build
 
 ARG API_BASE_URL="https://api.tags.ioxio.dev"
 

--- a/scanner/package.json
+++ b/scanner/package.json
@@ -31,7 +31,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@capacitor-community/barcode-scanner": "git://github.com/capacitor-community/barcode-scanner.git",
+    "@capacitor-community/barcode-scanner": "https://github.com/capacitor-community/barcode-scanner/tarball/ec289b59d0eaa46bc9afa1ed3e43f44733798913",
     "@capacitor/android": "^5.2.3",
     "@capacitor/app": "^5.0.6",
     "@capacitor/cli": "^5.2.3",

--- a/scanner/pnpm-lock.yaml
+++ b/scanner/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   '@capacitor-community/barcode-scanner':
-    specifier: git://github.com/capacitor-community/barcode-scanner.git
-    version: github.com/capacitor-community/barcode-scanner/ec289b59d0eaa46bc9afa1ed3e43f44733798913(@capacitor/core@5.2.3)
+    specifier: https://github.com/capacitor-community/barcode-scanner/tarball/ec289b59d0eaa46bc9afa1ed3e43f44733798913
+    version: '@github.com/capacitor-community/barcode-scanner/tarball/ec289b59d0eaa46bc9afa1ed3e43f44733798913(@capacitor/core@5.2.3)'
   '@capacitor/android':
     specifier: ^5.2.3
     version: 5.2.3(@capacitor/core@5.2.3)
@@ -2569,9 +2569,9 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  github.com/capacitor-community/barcode-scanner/ec289b59d0eaa46bc9afa1ed3e43f44733798913(@capacitor/core@5.2.3):
-    resolution: {tarball: https://codeload.github.com/capacitor-community/barcode-scanner/tar.gz/ec289b59d0eaa46bc9afa1ed3e43f44733798913}
-    id: github.com/capacitor-community/barcode-scanner/ec289b59d0eaa46bc9afa1ed3e43f44733798913
+  '@github.com/capacitor-community/barcode-scanner/tarball/ec289b59d0eaa46bc9afa1ed3e43f44733798913(@capacitor/core@5.2.3)':
+    resolution: {tarball: https://github.com/capacitor-community/barcode-scanner/tarball/ec289b59d0eaa46bc9afa1ed3e43f44733798913}
+    id: '@github.com/capacitor-community/barcode-scanner/tarball/ec289b59d0eaa46bc9afa1ed3e43f44733798913'
     name: '@capacitor-community/barcode-scanner'
     version: 4.0.1
     peerDependencies:


### PR DESCRIPTION
I found out that the build issue was caused by pnpm 9.x, the 8.x series worked fine.

Then further managed to track down the issue to installing from git and while checking through the pnpm docs I realized one could actually instead install it from a tarball provided by GitHub, so I decided to give that a go.

Now switched to install the `@capacitor-community/barcode-scanner` from a tarball and it works nicely with latest pnpm and thus also latest docker image.