### PR TITLE
Change redirects to scanner to use https instead of http

### DIFF
--- a/landing_page/nginx/conf.d/default.conf
+++ b/landing_page/nginx/conf.d/default.conf
@@ -20,7 +20,8 @@ server {
 
     # Redirects
     location /q/ {
-        return 301 $scheme://scanner.tags.ioxio.dev$request_uri;
+        # We're behind a reverse proxy, use https and not $scheme
+        return 301 https://scanner.tags.ioxio.dev$request_uri;
     }
 
     # Static .well-known files, this is a demo so we'll want to disable caching


### PR DESCRIPTION
The container is behind a reverse proxy, so nginx believes it's serving stuff over http and thus using http as the scheme. The host of the URL is als hardcoded and will always be served over https, so we can hardcode it to use https instead without any downside.